### PR TITLE
utilities/migrate/migrate.js to upgrade backup data to current bhima.sql build

### DIFF
--- a/server/sql/bhima.sql
+++ b/server/sql/bhima.sql
@@ -268,11 +268,11 @@ create table `account` (
   key `account_type_id` (`account_type_id`),
   key `enterprise_id` (`enterprise_id`),
   key `cc_id`         (`cc_id`),
-  key `pc_id`         (`pc_id`),
+  -- key `pc_id`         (`pc_id`),
   constraint foreign key (`account_type_id`) references `account_type` (`id`),
   constraint foreign key (`enterprise_id`) references `enterprise` (`id`),
-  constraint foreign key (`cc_id`)         references `cost_center` (`id`),
-  constraint foreign key (`pc_id`)         references `profit_center` (`id`)
+  constraint foreign key (`cc_id`)         references `cost_center` (`id`)
+  -- constraint foreign key (`pc_id`)         references `profit_center` (`id`)
 ) engine=innodb;
 
 drop table if exists `creditor_group`;

--- a/utilities/migrate/migrate.js
+++ b/utilities/migrate/migrate.js
@@ -64,6 +64,15 @@ function rip (key, dataset) {
     count += 1;
     var end = dataset.indexOf(');', idx + query.length + 3);
     var statement = dataset.substring(idx, end+2);
+    if (key === '`posting_journal`') { 
+      statement = statement.replace('VALUES', "(`uuid`, `project_id`, `fiscal_year_id`, `period_id`, `trans_id`, `trans_date`, `doc_num`, `description`, `account_id`, `debit`, `credit`, `debit_equiv`, `credit_equiv`, `currency_id`, `deb_cred_uuid`, `deb_cred_type`, `inv_po_id`, `comment`, `cost_ctrl_id`, `origin_id`, `user_id`, `cc_id`) VALUES ");
+    }
+    if (key === '`sale`') {
+      statement = statement.replace('VALUES', "(`project_id`, `reference`, `uuid`, `cost`, `currency_id`, `debitor_uuid`, `seller_id`, `discount`, `invoice_date`, `note`, `posted`, `timestamp`) VALUES ");
+    }
+    if (key === '`account`') {
+      statement = statement.replace('VALUES', "(`id`, `account_type_id`, `enterprise_id`, `account_number`, `account_txt`, `parent`, `fixed`, `locked`, `cc_id`, `pc_id`) VALUES");
+    }
     statements.push(statement);
     idx = dataset.indexOf(query, idx+1);
   }


### PR DESCRIPTION
In this pull request:
1. migrate.js corrects for column name changes in bhima.sql for current dropbox datasets
2. bhima.sql foreign keys for pc_id lifted to allow building the current dataset.

Usage:

``` bash
# unzip bhima_$timestamp.sql into in.sql
node migrate.js in.sql out.sql
mysql -u root -p
# enter password
source server/sql/bhima.sql; source utilities/migrate/out.sql;
```
