### PR TITLE
Correction defilement

### DIFF
--- a/client/src/css/bhima.css
+++ b/client/src/css/bhima.css
@@ -130,7 +130,7 @@ td.visible-print {
 
 #bhima-tree {
   padding-top: 20px;
-  height: 400px;
+  height: 70%;
   overflow: auto;
 }
 


### PR DESCRIPTION
[bhima.css]
# bhima_tree {...}

On a mis height:70% parce que sans cela les liens de l'arbre depassent les boutons
overflow:auto pour supporter le scroll
