### PR TITLE
Migrate route/data.js to using router pattern

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -43,7 +43,7 @@ var report            = require('./routes/report')(db, sanitize, util),
     depotRouter       = require('./routes/depot')(db, sanitize, store),
     tree              = require('./routes/tree')(db, parser),
     drugRouter        = require('./routes/drug')(db),
-    api               = require('./routes/data')(db, parser),
+    dataRouter        = require('./routes/data')(db, parser, express.Router()),
     serviceDist       = require('./routes/serviceDist')(db, parser, journal, uuid),
     consumptionLoss   = require('./routes/consumptionLoss')(db, parser, journal, uuid);
 
@@ -71,12 +71,8 @@ app.get('/', function (req, res, next) {
   res.sendfile(cfg.rootFile);
 });
 
-app.route('/data/')
-  .get(api.get)
-  .put(api.put)
-  .post(api.post);
-
-app.delete('/data/:table/:column/:value', api.delete);
+// data routes
+app.use('/data', dataRouter);
 
 app.post('/purchase', function (req, res, next) {
   createPurchase.run(req.session.user_id, req.body)

--- a/server/routes/data.js
+++ b/server/routes/data.js
@@ -1,5 +1,5 @@
 // server/routes/data.js
-//
+
 // Route: /data/
 //
 // This module handles translated HTTP
@@ -9,26 +9,25 @@
 var url = require('url'),
     qs = require('querystring');
 
-module.exports = function dataRouter(db, parser) {
+module.exports = function dataRouter(db, parser, router) {
   'use strict';
 
-  var mod = {};
-
-  mod.get = function (req, res, next) {
+  router.get('/', function (req, res, next) {
     var query, data, sql;
 
     query = qs.parse(decodeURI(url.parse(req.url).query)).q;
     data = JSON.parse(query);
     sql = parser.select(data);
+
     db.exec(sql)
     .then(function (rows) {
       res.send(rows);
     })
     .catch(next)
     .done();
-  };
+  });
 
-  mod.put = function (req, res, next) {
+  router.put('/', function (req, res, next) {
     // TODO: change the client to stop packaging data in an array...
     var sql = parser.update(req.body.table, req.body.data[0], req.body.pk[0]);
 
@@ -38,9 +37,9 @@ module.exports = function dataRouter(db, parser) {
     })
     .catch(next)
     .done();
-  };
+  });
 
-  mod.post = function (req, res, next) {
+  router.post('/', function (req, res, next) {
     // TODO: change the client to stop packaging data in an array...
     var sql = parser.insert(req.body.table, req.body.data);
 
@@ -50,9 +49,9 @@ module.exports = function dataRouter(db, parser) {
     })
     .catch(next)
     .done();
-  };
+  });
 
-  mod.delete = function (req, res, next) {
+  router.delete('/:table/:column/:value', function (req, res, next) {
     var sql = parser.delete(req.params.table, req.params.column, req.params.value);
     db.exec(sql)
     .then(function () {
@@ -60,8 +59,8 @@ module.exports = function dataRouter(db, parser) {
     })
     .catch(next)
     .done();
-  };
+  });
 
-  return mod;
+  return router;
 };
 


### PR DESCRIPTION
Using express.Router() allows us to modularize the application extensively.  This PR migrates data routes to using the router pattern.
