### PR TITLE
Purchase order bug

### DIFF
--- a/client/src/partials/purchase/create/purchase.html
+++ b/client/src/partials/purchase/create/purchase.html
@@ -151,7 +151,7 @@
                 <input
                 class="form-invoice"
                 type="text"
-                typeahead-template-url="invoiceListItem.html"
+                typeahead-template-url="/partials/templates/invoiceListItem.tmpl.html"
                 ng-model="purchaseItem.selectedReference"
                 typeahead="inventoryItem as inventoryItem.code for inventoryItem in inventory.data | filter:$viewValue | limitTo:8"
                 typeahead-on-select="updatePurchaseItem(purchaseItem, purchaseItem.selectedReference)"


### PR DESCRIPTION
The only problem I came across on the page was the typeahead requesting a file that didn't exist - this is due to a restructure of template files, and caused the page to log out. Simply updated the reference.
