### PR TITLE
Fixed location translation item in patient search

### DIFF
--- a/client/src/partials/records/patient_records/patient_records.html
+++ b/client/src/partials/records/patient_records/patient_records.html
@@ -102,7 +102,8 @@
           <button 
             class="btn btn-default btn-sm"
             ng-click="session.locationSearch=!session.locationSearch">
-            {{session.locationSearch ? 'Enlever la localisation dans la recherche' : 'Inclure la localisation dans la recherche'}}</button>
+            {{session.locationSearch ? "PATIENT_RECORDS.REMOVE_LOCATION_SEARCH" :  
+            "PATIENT_RECORDS.INCLUDE_LOCATION_SEARCH" | translate }}</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixed the translation on the include/remove language button on the patient search partial.
