### PR TITLE
Refactor/languages

### DIFF
--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -251,7 +251,7 @@ function bhimaconfig($routeProvider) {
     templateUrl: 'partials/print/test.html'
   })
   .when('/settings/:route?', {
-    controller: 'settings',
+    controller: 'Settings as SettingsCtrl',
     templateUrl: 'partials/settings/settings.html'
   })
   .when('/patient/group/assignment/', {

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -757,13 +757,14 @@ function translateConfig($translateProvider) {
   });
 
   $translateProvider.useSanitizeValueStrategy('escape');
-
+  
+  // TODO Load/ template default enterprise language before bootstrapping angular
   $translateProvider.preferredLanguage('fr');
 }
 
 function localeConfig(tmhDynamicLocaleProvider) { 
-
-  // TODO Hardcoded default translation/ localisation
+  
+  // TODO Load/ template default enterprise language before bootstrapping angular
   tmhDynamicLocaleProvider.localeLocationPattern('/i18n/locale/angular-locale_{{locale}}.js');
   tmhDynamicLocaleProvider.defaultLocale('fr-be');
 }
@@ -776,8 +777,9 @@ function authConfig($httpProvider) {
   }]);
 }
 
-// Redirect to login if not signed in.
 function startupConfig($rootScope, $location, SessionService) {
+  
+  // Redirect to login if not signed in.
   $rootScope.$on('$routeChangeStart', function (event, next) {
     if (!SessionService.user) {
       $location.url('/login');

--- a/client/src/partials/auth/login.js
+++ b/client/src/partials/auth/login.js
@@ -95,7 +95,9 @@ function LoginController($scope, $translate, $location, $http, $timeout, Appcach
 
   // switches languages
   function setLanguage(lang) {
-    $translate.use(lang.key);
-    cache.put('language', { current: lang.key });
+
+    // TODO Use a translation service to fetch languages and configure cache
+    $translate.use(lang.translate_key);
+    cache.put('language', lang);
   }
 }

--- a/client/src/partials/bhima/application.js
+++ b/client/src/partials/bhima/application.js
@@ -16,9 +16,30 @@ angular.module('bhima.controllers')
 
     cache.fetch('language')
     .then(function (language) {
+
       if (language) {
+        
+        // Use previously set language
+        // TODO Use a translation service to fetch languages and configure cache
         $translate.use(language.translate_key);
         tmhDynamicLocale.set(language.locale_key);
+      } else { 
+        
+        // FIXME SessionService values _cannot_ be relied upon unless the user has 
+        // already logged in once - they cannot be used on initial load
+        if (SessionService.enterprise) { 
+
+          connect.req('languages')
+          .then(function (languageStore) { 
+            var enterpriseLanguage = languageStore.get(SessionService.enterprise.language_id);
+            
+            // TODO Use a translation service to fetch languages and configure cache
+            // Default to enterprise language
+            $translate.use(enterpriseLanguage.translate_key);
+            tmhDynamicLocale.set(enterpriseLanguage.locale_key);
+            cache.put('language', enterpriseLanguage);
+          });
+        }
       }
     });
 
@@ -79,7 +100,6 @@ angular.module('bhima.controllers')
         appstate.set('user', SessionService.user);
       });
 
-      // FIXME
       // set DEPRECATED appstate variables until we can change them
       // throughout the application.
       appstate.register('fiscalYears', function (data) {

--- a/client/src/partials/bhima/application.js
+++ b/client/src/partials/bhima/application.js
@@ -17,8 +17,8 @@ angular.module('bhima.controllers')
     cache.fetch('language')
     .then(function (language) {
       if (language) {
-        $translate.use(language.translateKey);
-        tmhDynamicLocale.set(language.localeKey);
+        $translate.use(language.translate_key);
+        tmhDynamicLocale.set(language.locale_key);
       }
     });
 

--- a/client/src/partials/settings/settings.html
+++ b/client/src/partials/settings/settings.html
@@ -7,11 +7,8 @@
     <div class="col-xs-5">
       <div class="form-group">
         <label for="select-language">{{ "SETTINGS.LANGUAGE" | translate }}</label>
-        <select id="select-language" ng-model="settings.language" ng-change="updateLanguage(settings.language)" class="form-bhima">
+        <select id="select-language" ng-options="language.id as language.name for language in languages" ng-model="settings.language" ng-change="updateLanguage(settings.language)" class="form-bhima">
           <option value="" disabled="disabled" selected>{{ "SELECT.LANGUAGE" | translate }}</option>
-          <option value="en">{{ "LANGUAGES.ENGLISH" | translate }}</option>
-          <option value="fr">{{ "LANGUAGES.FRENCH" | translate }}</option>
-          <option value="ln">{{ "LANGUAGES.LINGALA" | translate }}</option>
         </select>
       </div>
 

--- a/client/src/partials/settings/settings.html
+++ b/client/src/partials/settings/settings.html
@@ -7,7 +7,7 @@
     <div class="col-xs-5">
       <div class="form-group">
         <label for="select-language">{{ "SETTINGS.LANGUAGE" | translate }}</label>
-        <select id="select-language" ng-options="language.id as language.name for language in languages" ng-model="settings.language" ng-change="updateLanguage(settings.language)" class="form-bhima">
+        <select id="select-language" ng-options="language.id as language.name for language in SettingsCtrl.languages" ng-model="SettingsCtrl.language" ng-change="SettingsCtrl.updateLanguage()" class="form-bhima">
           <option value="" disabled="disabled" selected>{{ "SELECT.LANGUAGE" | translate }}</option>
         </select>
       </div>
@@ -21,7 +21,7 @@
     </div>
   </div>
 
-  <button ng-if="!!url" class="btn btn-sm btn-default" ng-click="back()">
+  <button ng-if="!!SettingsCtrl.url" class="btn btn-sm btn-default" ng-click="SettingsCtrl.back()">
     <span class="glyphicon glyphicon-circle-arrow-left"></span> {{ "UTIL.BACK" | translate }}
   </button>
 </main>

--- a/client/src/partials/settings/settings.js
+++ b/client/src/partials/settings/settings.js
@@ -1,49 +1,48 @@
-angular.module('bhima.controllers')
-.controller('settings', [
-  '$scope',
-  '$routeParams',
-  '$translate',
-  '$location',
-  'appcache',
-  'messenger',
-  'tmhDynamicLocale',
-  'connect',
-  function($scope, $routeParams, $translate, $location, Appcache, messenger, tmhDynamicLocale, connect) {
-    
-    var languageStore;
+angular.module('bhima.controllers').controller('Settings', Settings);
 
-    $scope.url = $routeParams.url || '';
-    var cache = new Appcache('preferences');
+Settings.$inject = ['$routeParams','$translate','$location','appcache','tmhDynamicLocale','connect'];
 
-    fetchAvailableLanguages();
-    
+function Settings($routeParams, $translate, $location, Appcache, tmhDynamicLocale, connect) {
+  var languageStore;
+  var viewModel = this;
+  var cache = new Appcache('preferences');
+
+  viewModel.url = $routeParams.url || '';
+
+  fetchAvailableLanguages();
+  lookupCachedLanguage();
+  
+  function lookupCachedLanguage() { 
     cache.fetch('language')
     .then(function (res) {
       if (res) {
-        $scope.settings = { language: res.id };
+        viewModel.language = res.id;
       }
     });
-
-    function fetchAvailableLanguages() { 
-      connect.req('languages')
-        .then(function (store) { 
-
-          languageStore = store;
-          $scope.languages = languageStore.data;
-        });
-    }
-
-    $scope.updateLanguage = function updateLanuage(key) {
-      var language = languageStore.get(key);
-      
-      $translate.use(language.translate_key);
-      tmhDynamicLocale.set(language.locale_key);
-
-      cache.put('language', language);
-    };
-
-    $scope.back = function () {
-      $location.url($scope.url);
-    };
   }
-]);
+
+  function fetchAvailableLanguages() { 
+    connect.req('languages')
+      .then(function (store) { 
+
+        languageStore = store;
+        viewModel.languages = languageStore.data;
+      });
+  }
+  
+  function updateLanguage(key) {
+    var language = languageStore.get(viewModel.language);
+    
+    $translate.use(language.translate_key);
+    tmhDynamicLocale.set(language.locale_key);
+
+    cache.put('language', language);
+  };
+  
+  function back() {
+    $location.url(viewModel.url);
+  };
+  
+  viewModel.updateLanguage = updateLanguage;
+  viewModel.back = back;
+}

--- a/client/src/partials/settings/settings.js
+++ b/client/src/partials/settings/settings.js
@@ -7,45 +7,37 @@ angular.module('bhima.controllers')
   'appcache',
   'messenger',
   'tmhDynamicLocale',
-  'store',
-  function($scope, $routeParams, $translate, $location, Appcache, messenger, tmhDynamicLocale, Store) {
+  'connect',
+  function($scope, $routeParams, $translate, $location, Appcache, messenger, tmhDynamicLocale, connect) {
     
-    // TODO issue discussing DB modelling of languages, quick suggestion (id, label, translateKey, localeKey)
-    var languageStore = new Store({identifier : 'translateKey'});
-    var languages = [
-      {
-        translateKey : 'en',
-        localeKey : 'en-us',
-        label : 'English'
-      },
-      {
-        translateKey : 'fr',
-        localeKey : 'fr-be',
-        label : 'French'
-      },
-      {
-        translateKey : 'ln',
-        localeKey : 'fr-cd',
-        label : 'Lingala'
-      }
-    ];
-    languageStore.setData(languages);
-    
+    var languageStore;
+
     $scope.url = $routeParams.url || '';
     var cache = new Appcache('preferences');
 
+    fetchAvailableLanguages();
+    
     cache.fetch('language')
     .then(function (res) {
       if (res) {
-        $scope.settings = { language: res.translateKey };
+        $scope.settings = { language: res.id };
       }
     });
+
+    function fetchAvailableLanguages() { 
+      connect.req('languages')
+        .then(function (store) { 
+
+          languageStore = store;
+          $scope.languages = languageStore.data;
+        });
+    }
 
     $scope.updateLanguage = function updateLanuage(key) {
       var language = languageStore.get(key);
       
-      $translate.use(language.translateKey);
-      tmhDynamicLocale.set(language.localeKey);
+      $translate.use(language.translate_key);
+      tmhDynamicLocale.set(language.locale_key);
 
       cache.put('language', language);
     };

--- a/client/src/partials/settings/settings.js
+++ b/client/src/partials/settings/settings.js
@@ -32,7 +32,8 @@ function Settings($routeParams, $translate, $location, Appcache, tmhDynamicLocal
   
   function updateLanguage(key) {
     var language = languageStore.get(viewModel.language);
-    
+   
+    // TODO Use a translation service to fetch languages and configure cache
     $translate.use(language.translate_key);
     tmhDynamicLocale.set(language.locale_key);
 

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -41,7 +41,7 @@ exports.login = function (req, res, next) {
     //   the current enterprise
     //   the current project
     sql =
-      'SELECT e.id, e.name, e.abbr, e.phone, e.email, e.location_id, e.currency_id, e.po_box ' +
+      'SELECT e.id, e.name, e.abbr, e.phone, e.email, e.location_id, e.currency_id, e.language_id, e.po_box ' +
       'FROM enterprise AS e WHERE e.id = ?;';
 
     return db.exec(sql, [user.enterprise_id]);

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -106,7 +106,7 @@ exports.getLanguages = function (req, res, next) {
   'use strict';
 
   var sql =
-    'SELECT lang.id, lang.name, lang.key FROM language AS lang;';
+    'SELECT lang.id, lang.name, lang.translate_key, lang.locale_key FROM language AS lang;';
 
   db.exec(sql)
   .then(function (rows) {

--- a/server/models/development/update/synt.sql
+++ b/server/models/development/update/synt.sql
@@ -217,3 +217,22 @@ ALTER TABLE `rubric`
 CHANGE `is_advance` `is_advance` tinyint(1) DEFAULT '0';
 ALTER TABLE `rubric`  
 CHANGE `is_social_care` `is_social_care` tinyint(1) DEFAULT '0';
+
+-- @sfount
+-- 2015-15-09
+-- Model languages
+
+DROP TABLE IF EXISTS `language`;
+CREATE TABLE `language` (
+  `id` smallint(5) unsigned NOT NULL,
+  `title` varchar(35) NOT NULL,
+  `description` varchar(50),
+  `translateKey` varchar(5) NOT NULL,
+  `localeKey` varchar(5) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+INSERT INTO `language` VALUES
+  (1, 'English', NULL, 'en', 'en-us'),
+  (2, 'French', NULL, 'fr', 'fr-cd');
+-- (3, 'English (EU)', 'en', 'en-uk')
+

--- a/server/models/development/update/synt.sql
+++ b/server/models/development/update/synt.sql
@@ -221,18 +221,22 @@ CHANGE `is_social_care` `is_social_care` tinyint(1) DEFAULT '0';
 -- @sfount
 -- 2015-15-09
 -- Model languages
+-- UPDATE - Language table exists but did not propegate through application language settings
 
-DROP TABLE IF EXISTS `language`;
-CREATE TABLE `language` (
-  `id` smallint(5) unsigned NOT NULL,
-  `title` varchar(35) NOT NULL,
-  `description` varchar(50),
-  `translateKey` varchar(5) NOT NULL,
-  `localeKey` varchar(5) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/* DROP TABLE IF EXISTS `language`; */
+/* CREATE TABLE `language` ( */
+  /* `id` smallint(5) unsigned NOT NULL, */
+  /* `title` varchar(35) NOT NULL, */
+  /* `description` varchar(50), */
+  /* `translate_key` varchar(5) NOT NULL, */
+  /* `locale_key` varchar(5) NOT NULL */
+/* ) ENGINE=InnoDB DEFAULT CHARSET=latin1; */
 
-INSERT INTO `language` VALUES
-  (1, 'English', NULL, 'en', 'en-us'),
-  (2, 'French', NULL, 'fr', 'fr-cd');
--- (3, 'English (EU)', 'en', 'en-uk')
+ALTER TABLE `language` CHANGE `key` `translate_key` varchar(5) NOT NULL;
+ALTER TABLE `language` ADD locale_key varchar(5);
+  
+UPDATE `language` SET locale_key = 'en-us' WHERE id = 1;
+UPDATE `language` SET locale_key = 'fr-cd' WHERE id = 2;
+UPDATE `language` SET locale_key = 'fr-cd' WHERE id = 3;
 
+ALTER TABLE `language` MODIFY `locale_key` varchar(5) NOT NULL;

--- a/server/models/development/update/synt.sql
+++ b/server/models/development/update/synt.sql
@@ -240,3 +240,13 @@ UPDATE `language` SET locale_key = 'fr-cd' WHERE id = 2;
 UPDATE `language` SET locale_key = 'fr-cd' WHERE id = 3;
 
 ALTER TABLE `language` MODIFY `locale_key` varchar(5) NOT NULL;
+
+-- @sfount
+-- 2015-17-09
+-- Model enterprise (application) wide default language 
+ALTER TABLE `enterprise` ADD language_id tinyint(3);
+  
+-- Set tshikaji's default language to French
+UPDATE `enterprise` SET language_id = 1;
+
+ALTER TABLE `enterprise` MODIFY language_id tinyint(3) NOT NULL;


### PR DESCRIPTION
- Model languages in the database vs. using *hard coded key strings* in the settings page. 
- Standardised locale + language translation across different pages (both settings and login) 
- Propagate language models (using ids etc.) throughout language modules and caches 

I cannot see any additional places that languages or locale will have to be updated other than settings and login, the merits of wrapping these functions in a service can be discussed (although this is a relatively small job). This can either be added during merge or separately. 

*(This branch was developed some time ago, I will update it with the latest development and let someone else can merge it)*