### PR TITLE
Fixing select service in return medecines module

### DIFF
--- a/client/src/partials/stock/service_return_stock/service_return_stock.js
+++ b/client/src/partials/stock/service_return_stock/service_return_stock.js
@@ -42,8 +42,7 @@ function ServiceReturnStockController($routeParams, $http, $q, $translate, $loca
       identifier : 'id',
       tables : {
         'service' : { columns : ['id', 'name', 'cost_center_id'] }
-      },
-      where : ['service.project_id=' + SessionService.project.id]
+      }
     }
   };
 


### PR DESCRIPTION
This PR fixes the `Return distribution from service` module. 

To run correctly the app, please : 
- Don't use `STRICT_ALL_TABLES` mysql mode 
- Use the external file db.sql
- Then execute the /server/models/update/synt.sql file

NOTA: The exchange rate module doesn't have a bug when we try to define a new exchange rate when we are not in `STRICT_ALL_TABLES` mysql mode 